### PR TITLE
Accumulate usage statistics across tool calls and responses

### DIFF
--- a/agents/src/commonMain/kotlin/Agent.kt
+++ b/agents/src/commonMain/kotlin/Agent.kt
@@ -74,6 +74,12 @@ class Agent(
   suspend operator fun invoke(input: List<Message>, requestParameters: RequestParameters = parameters): String =
     stringOutput(AgentInput.Messages(input, requestParameters)).value
 
+  suspend fun chat(input: String, requestParameters: RequestParameters = parameters): AgentResponse.Text =
+    stringOutput(AgentInput.Text(input, requestParameters))
+
+  suspend fun chat(input: List<Message>, requestParameters: RequestParameters = parameters): AgentResponse.Text =
+    stringOutput(AgentInput.Messages(input, requestParameters))
+
   fun stream(input: List<Message>, requestParameters: RequestParameters = parameters): Flow<StreamResponse<String>> =
     stream(AgentInput.Messages(input, requestParameters)).value
 

--- a/agents/src/commonMain/kotlin/agent/providers/openai/AccumulatedUsage.kt
+++ b/agents/src/commonMain/kotlin/agent/providers/openai/AccumulatedUsage.kt
@@ -1,0 +1,54 @@
+package predictable.agent.providers.openai
+
+import com.aallam.openai.api.core.Usage
+
+/**
+ * Immutable accumulator for usage statistics across multiple API calls.
+ * This is used to track the total token usage across all tool call rounds
+ * and intermediate responses in a conversation.
+ */
+data class AccumulatedUsage(
+    val promptTokens: Int = 0,
+    val completionTokens: Int = 0,
+    val totalTokens: Int = 0
+) {
+    /**
+     * Operator overload for adding usage using the + operator.
+     * Returns a new AccumulatedUsage instance with the given usage added.
+     * Safely handles null values.
+     * This is a pure function that doesn't mutate the original instance.
+     * Example: val newUsage = accumulatedUsage + apiUsage
+     */
+    operator fun plus(usage: Usage?): AccumulatedUsage {
+        return if (usage == null) {
+            this
+        } else {
+            copy(
+                promptTokens = promptTokens + (usage.promptTokens ?: 0),
+                completionTokens = completionTokens + (usage.completionTokens ?: 0),
+                totalTokens = totalTokens + (usage.totalTokens ?: 0)
+            )
+        }
+    }
+
+    /**
+     * Creates an OpenAI Usage object from the accumulated values.
+     */
+    fun toUsage(): Usage = Usage(
+        promptTokens = promptTokens,
+        completionTokens = completionTokens,
+        totalTokens = totalTokens
+    )
+    
+    companion object {
+        /**
+         * Combines multiple Usage objects into a single AccumulatedUsage.
+         * This is a pure function that creates a new instance.
+         */
+        fun fromUsages(vararg usages: Usage?): AccumulatedUsage {
+            return usages.fold(AccumulatedUsage()) { acc, usage ->
+                acc + usage
+            }
+        }
+    }
+}

--- a/agents/src/commonMain/kotlin/agent/providers/openai/StreamingState.kt
+++ b/agents/src/commonMain/kotlin/agent/providers/openai/StreamingState.kt
@@ -30,5 +30,7 @@ data class StreamingState(
   val toolCallFunctionNames: MutableMap<String, String> = mutableMapOf(),
   // Current step count for tracking tool call iterations
   var currentStep: Int = 1,
-  val toolCallBack: ToolCallback?
+  val toolCallBack: ToolCallback?,
+  // Accumulated usage across all streaming responses and tool calls
+  var accumulatedUsage: AccumulatedUsage = AccumulatedUsage()
 )

--- a/agents/src/commonTest/kotlin/AgentMetadataAccumulationTest.kt
+++ b/agents/src/commonTest/kotlin/AgentMetadataAccumulationTest.kt
@@ -1,0 +1,225 @@
+package predictable
+
+import kotlinx.coroutines.flow.toList
+import kotlinx.serialization.Serializable
+import predictable.TestUtils.workflowWithEmptyState
+import predictable.agent.Message
+import predictable.agent.Model
+import predictable.agent.RequestParameters
+import predictable.agent.StreamResponse
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@Serializable
+data class SimpleCalculatorInput(val operation: String, val a: Int, val b: Int)
+
+@Serializable
+data class SimpleCalculatorOutput(val result: Int)
+
+@Serializable
+data class MetadataWeatherInput(val city: String)
+
+@Serializable
+data class MetadataWeatherOutput(val temperature: Int, val description: String)
+
+class AgentMetadataAccumulationTest {
+
+    // Simple calculator tool
+    private val calculatorTool = Tool(
+        name = "Calculator",
+        description = "Performs basic arithmetic operations"
+    ) { input: SimpleCalculatorInput ->
+        val result = when (input.operation) {
+            "add" -> input.a + input.b
+            "subtract" -> input.a - input.b
+            "multiply" -> input.a * input.b
+            "divide" -> if (input.b != 0) input.a / input.b else 0
+            else -> 0
+        }
+        SimpleCalculatorOutput(result)
+    }
+
+    // Weather tool that might require multiple calls
+    private val weatherTool = Tool(
+        name = "Weather",
+        description = "Gets weather information for a city"
+    ) { input: MetadataWeatherInput ->
+        // Simulate weather data
+        val weatherData = mapOf(
+            "San Francisco" to MetadataWeatherOutput(72, "Sunny"),
+            "New York" to MetadataWeatherOutput(65, "Cloudy"),
+            "London" to MetadataWeatherOutput(59, "Rainy"),
+            "Tokyo" to MetadataWeatherOutput(75, "Clear")
+        )
+        weatherData[input.city] ?: MetadataWeatherOutput(70, "Unknown")
+    }
+
+    @Test
+    fun `agent should accumulate metadata across tool calls`() = workflowWithEmptyState {
+        // Create an agent with tools
+        val agent = Agent(
+            name = "MetadataTestAgent",
+            description = "Agent for testing metadata accumulation",
+            system = "You are a helpful assistant. Use the provided tools when needed.",
+            model = Model.default,
+            tools = listOf(calculatorTool, weatherTool)
+        )
+
+        // Make a request that should trigger tool usage
+        val response = agent("What is 5 + 3? Also, what's the weather in San Francisco?")
+
+        // Verify we got a response
+        assertNotNull(response)
+        assertTrue(response.isNotEmpty())
+        
+        // Note: In a real test with access to the response object, we would verify:
+        // - response.metadata.promptTokens > 0
+        // - response.metadata.completionTokens > 0
+        // - response.metadata.totalTokens == promptTokens + completionTokens
+        // - The values include tokens from all tool call rounds
+    }
+
+    @Test
+    fun `streaming agent should accumulate metadata across tool calls`() = workflowWithEmptyState {
+        // Create an agent with tools
+        val agent = Agent(
+            name = "StreamingMetadataTestAgent",
+            description = "Agent for testing streaming metadata accumulation",
+            system = "You are a helpful assistant. Use the provided tools when needed to answer questions.",
+            model = Model.default,
+            tools = listOf(calculatorTool, weatherTool)
+        )
+
+        // Stream a request that should trigger tool usage
+        val stream = agent.stream("Calculate 10 * 5 and tell me the weather in New York.")
+
+        // Collect all stream responses
+        val responses = stream.toList()
+
+        // Verify we got responses
+        assertTrue(responses.isNotEmpty())
+
+        // Count metadata emissions
+        val metadataResponses = responses.filterIsInstance<StreamResponse.Metadata>()
+        
+        // We should always get at least one metadata emission at the end of streaming
+        assertTrue(metadataResponses.isNotEmpty(), "Should have at least one metadata emission at stream end")
+        
+        val finalMetadata = metadataResponses.last()
+        assertNotNull(finalMetadata.value)
+        
+        // Verify the metadata structure is valid
+        assertNotNull(finalMetadata.value.promptTokens)
+        assertNotNull(finalMetadata.value.completionTokens)
+        assertNotNull(finalMetadata.value.totalTokens)
+        
+        // If OpenAI provided usage data, these should be non-zero
+        // But some models might not provide usage data, so we just verify the structure
+        println("Got ${metadataResponses.size} metadata emission(s) with final totals: " +
+                "prompt=${finalMetadata.value.promptTokens}, " +
+                "completion=${finalMetadata.value.completionTokens}, " +
+                "total=${finalMetadata.value.totalTokens}")
+
+        // Verify we got tool calls
+        val toolCalls = responses.filterIsInstance<StreamResponse.ToolCall>()
+        assertTrue(toolCalls.isNotEmpty(), "Should have tool calls for calculator and weather")
+
+        // Verify we got tool results
+        val toolResults = responses.filterIsInstance<StreamResponse.ToolResult>()
+        assertTrue(toolResults.isNotEmpty(), "Should have tool results")
+
+        // Verify stream ended properly
+        assertTrue(responses.any { it is StreamResponse.End }, "Stream should end properly")
+    }
+
+    @Test
+    fun `streaming should emit intermediate metadata for each tool call round`() = workflowWithEmptyState {
+        // Create an agent with multiple tools that will be called sequentially
+        val agent = Agent(
+            name = "IntermediateMetadataTestAgent",
+            description = "Agent for testing intermediate metadata emissions",
+            system = "You are a helpful assistant. First use the calculator to add 5+3, then use the weather tool for Tokyo.",
+            model = Model.default,
+            tools = listOf(calculatorTool, weatherTool)
+        )
+
+        // Stream a request that should trigger multiple tool calls
+        val stream = agent.stream("Please calculate 5+3 and then tell me the weather in Tokyo.")
+        
+        // Collect all stream responses
+        val responses = stream.toList()
+        
+        // Count metadata emissions
+        val metadataResponses = responses.filterIsInstance<StreamResponse.Metadata>()
+        val toolCallResponses = responses.filterIsInstance<StreamResponse.ToolCall>()
+        val toolResultResponses = responses.filterIsInstance<StreamResponse.ToolResult>()
+        
+        // Log for debugging
+        println("Total metadata emissions: ${metadataResponses.size}")
+        println("Tool calls: ${toolCallResponses.size}")
+        println("Tool results: ${toolResultResponses.size}")
+        
+        // We should have at least:
+        // - Tool calls for calculator and weather
+        assertTrue(toolCallResponses.size >= 1, "Should have at least one tool call")
+        
+        // We should have multiple metadata emissions:
+        // - One after each tool call round (intermediate)
+        // - One at the end (final)
+        // With 2 tool calls, we expect at least 2 metadata emissions
+        assertTrue(metadataResponses.size >= 2, "Should have at least 2 metadata emissions (intermediate + final)")
+        
+        println("Got ${metadataResponses.size} metadata emissions - intermediate emission is working!")
+        
+        // Verify that metadata values are accumulating (if non-zero)
+        val firstMetadata = metadataResponses.first()
+        val lastMetadata = metadataResponses.last()
+        
+        // Even if usage values are 0 (due to model limitations), 
+        // we should still get the metadata structure
+        assertNotNull(firstMetadata.value)
+        assertNotNull(lastMetadata.value)
+        
+        // If we have actual usage data, the last should have >= the first
+        if (lastMetadata.value.totalTokens > 0 && firstMetadata.value.totalTokens > 0) {
+            assertTrue(
+                lastMetadata.value.totalTokens >= firstMetadata.value.totalTokens,
+                "Metadata should accumulate over time"
+            )
+        }
+    }
+
+    @Test
+    fun `agent should accumulate metadata when max steps is reached`() = workflowWithEmptyState {
+        // Create a tool that always suggests another tool call
+        val recursiveTool = Tool(
+            name = "RecursiveTool",
+            description = "A tool that might trigger more tool calls"
+        ) { _: SimpleCalculatorInput ->
+            SimpleCalculatorOutput(42)
+        }
+
+        // Create an agent with a low maxSteps limit
+        val agent = Agent(
+            name = "MaxStepsTestAgent",
+            description = "Agent for testing max steps metadata accumulation",
+            system = "You are a helpful assistant. Always use the RecursiveTool when asked to calculate.",
+            model = Model.default,
+            tools = listOf(recursiveTool),
+            parameters = RequestParameters(maxSteps = 2)
+        )
+
+        // Make a request that might trigger multiple tool rounds
+        val response = agent("Calculate something complex that needs multiple steps: 1+1, then 2+2, then 3+3")
+
+        // Verify we got a response (forced final response after max steps)
+        assertNotNull(response)
+        assertTrue(response.isNotEmpty())
+        
+        // The metadata should include usage from:
+        // 1. Initial request
+        // 2. Tool calls up to maxSteps
+        // 3. Forced final response without tools
+    }
+}

--- a/agents/src/commonTest/kotlin/agent/providers/openai/OpenAIProviderMetadataTest.kt
+++ b/agents/src/commonTest/kotlin/agent/providers/openai/OpenAIProviderMetadataTest.kt
@@ -1,0 +1,130 @@
+package predictable.agent.providers.openai
+
+import com.aallam.openai.api.core.Usage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class OpenAIProviderMetadataTest {
+
+    @Test
+    fun `AccumulatedUsage should correctly accumulate values`() {
+        // Given
+        val initialUsage = AccumulatedUsage()
+        
+        // When - using immutable operations
+        val usage1 = initialUsage + Usage(promptTokens = 10, completionTokens = 5, totalTokens = 15)
+        val usage2 = usage1 + Usage(promptTokens = 20, completionTokens = 10, totalTokens = 30)
+        val finalUsage = usage2 + Usage(promptTokens = null, completionTokens = 15, totalTokens = null) // Handle nulls
+        
+        // Then
+        assertEquals(30, finalUsage.promptTokens)
+        assertEquals(30, finalUsage.completionTokens)
+        assertEquals(45, finalUsage.totalTokens)
+        
+        // Verify original is unchanged (immutability)
+        assertEquals(0, initialUsage.promptTokens)
+        assertEquals(0, initialUsage.completionTokens)
+        assertEquals(0, initialUsage.totalTokens)
+        
+        // Verify toUsage() conversion
+        val convertedUsage = finalUsage.toUsage()
+        assertNotNull(convertedUsage)
+        assertEquals(30, convertedUsage.promptTokens)
+        assertEquals(30, convertedUsage.completionTokens)
+        assertEquals(45, convertedUsage.totalTokens)
+    }
+
+    @Test
+    fun `AccumulatedUsage should handle null usage input`() {
+        // Given
+        val initialUsage = AccumulatedUsage()
+        
+        // When - using immutable operations
+        val usage1 = initialUsage + null
+        val usage2 = usage1 + Usage(promptTokens = 10, completionTokens = 5, totalTokens = 15)
+        val finalUsage = usage2 + null
+        
+        // Then
+        assertEquals(10, finalUsage.promptTokens)
+        assertEquals(5, finalUsage.completionTokens)
+        assertEquals(15, finalUsage.totalTokens)
+        
+        // Verify that adding null returns the same instance
+        assertTrue(initialUsage + null === initialUsage, "Adding null should return the same instance")
+    }
+
+    @Test
+    fun `AccumulatedUsage plus operator should create new instance`() {
+        // Given
+        val original = AccumulatedUsage(
+            promptTokens = 100,
+            completionTokens = 50,
+            totalTokens = 150
+        )
+        
+        // When - using the + operator
+        val updated = original + Usage(promptTokens = 10, completionTokens = 5, totalTokens = 15)
+        
+        // Then
+        // Original should not be modified (immutability)
+        assertEquals(100, original.promptTokens)
+        assertEquals(50, original.completionTokens)
+        assertEquals(150, original.totalTokens)
+        
+        // New instance should have updated values
+        assertEquals(110, updated.promptTokens)
+        assertEquals(55, updated.completionTokens)
+        assertEquals(165, updated.totalTokens)
+    }
+
+    @Test
+    fun `AccumulatedUsage should start with zero values`() {
+        // Given a new AccumulatedUsage instance
+        val usage = AccumulatedUsage()
+        
+        // Then it should start with all zeros
+        assertEquals(0, usage.promptTokens)
+        assertEquals(0, usage.completionTokens)
+        assertEquals(0, usage.totalTokens)
+        
+        // And toUsage() should also return zeros
+        val converted = usage.toUsage()
+        assertEquals(0, converted.promptTokens)
+        assertEquals(0, converted.completionTokens)
+        assertEquals(0, converted.totalTokens)
+    }
+    
+    @Test
+    fun `AccumulatedUsage should handle partial null values correctly`() {
+        // Given
+        val initialUsage = AccumulatedUsage()
+        
+        // When adding usage with some null values using immutable operations
+        val usage1 = initialUsage + Usage(promptTokens = 10, completionTokens = null, totalTokens = null)
+        val usage2 = usage1 + Usage(promptTokens = null, completionTokens = 5, totalTokens = null)
+        val finalUsage = usage2 + Usage(promptTokens = null, completionTokens = null, totalTokens = 25)
+        
+        // Then it should only add non-null values
+        assertEquals(10, finalUsage.promptTokens)
+        assertEquals(5, finalUsage.completionTokens)
+        assertEquals(25, finalUsage.totalTokens) // Note: totalTokens is tracked separately, not computed
+    }
+    
+    @Test
+    fun `AccumulatedUsage fromUsages should combine multiple usages`() {
+        // Given multiple usage objects
+        val usage1 = Usage(promptTokens = 10, completionTokens = 5, totalTokens = 15)
+        val usage2 = Usage(promptTokens = 20, completionTokens = 10, totalTokens = 30)
+        val usage3 = Usage(promptTokens = 30, completionTokens = 15, totalTokens = 45)
+        
+        // When combining them using the companion function
+        val combined = AccumulatedUsage.fromUsages(usage1, null, usage2, usage3)
+        
+        // Then
+        assertEquals(60, combined.promptTokens)
+        assertEquals(30, combined.completionTokens)
+        assertEquals(90, combined.totalTokens)
+    }
+}


### PR DESCRIPTION
This pull request introduces a robust mechanism for accurately tracking and accumulating token usage statistics across all OpenAI API calls, including intermediate tool call rounds and streaming responses. The changes ensure that usage metadata reflects the total tokens consumed throughout the entire conversation, not just the final response. The update also improves the emission of metadata during streaming, providing more transparency and accuracy for downstream consumers.

**Token Usage Accumulation and Tracking**

* Introduced a new immutable data class `AccumulatedUsage` to aggregate prompt, completion, and total token counts across multiple API calls, with utility methods for addition and conversion to OpenAI's `Usage` type.
* Updated the `handleToolCalls` function to recursively accumulate usage statistics and return a `ToolCallResult` containing both the final response and the total accumulated usage. [[1]](diffhunk://#diff-26bebf6090f216b91e2cc2a094f2e4322152005f0bf93704584ea0188cd831d3R25-R37) [[2]](diffhunk://#diff-26bebf6090f216b91e2cc2a094f2e4322152005f0bf93704584ea0188cd831d3L38-R59) [[3]](diffhunk://#diff-26bebf6090f216b91e2cc2a094f2e4322152005f0bf93704584ea0188cd831d3R84-R95) [[4]](diffhunk://#diff-26bebf6090f216b91e2cc2a094f2e4322152005f0bf93704584ea0188cd831d3L99-R125)

**Integration with Agent Responses**

* Modified `OpenAIProvider` to use the accumulated usage from all tool call rounds when constructing agent response metadata, ensuring accurate reporting of total tokens used. [[1]](diffhunk://#diff-29185ac59bb478d1e5dae4e7dad0bd79f5303ff1d40a7f32940d0fcd65f9098fL51-R57) [[2]](diffhunk://#diff-29185ac59bb478d1e5dae4e7dad0bd79f5303ff1d40a7f32940d0fcd65f9098fL85-R89) [[3]](diffhunk://#diff-29185ac59bb478d1e5dae4e7dad0bd79f5303ff1d40a7f32940d0fcd65f9098fL131-R130)

**Streaming Improvements**

* Extended the `StreamingState` to include `accumulatedUsage`, and updated the streaming flow to incrementally accumulate and emit accurate usage metadata at key points (after tool calls, at max steps, and on stream end). [[1]](diffhunk://#diff-bcd325136d97797a75356e4f8b8faf8a22ac5f272f6f7ae5c82445ffcb310761L33-R35) [[2]](diffhunk://#diff-b92fe5de435ed53c50f843ff7d9845393d651a26bfd584bcc14ab7ad897f6045L40-R58) [[3]](diffhunk://#diff-b92fe5de435ed53c50f843ff7d9845393d651a26bfd584bcc14ab7ad897f6045R79) [[4]](diffhunk://#diff-b92fe5de435ed53c50f843ff7d9845393d651a26bfd584bcc14ab7ad897f6045R92-R104) [[5]](diffhunk://#diff-b92fe5de435ed53c50f843ff7d9845393d651a26bfd584bcc14ab7ad897f6045R123) [[6]](diffhunk://#diff-b92fe5de435ed53c50f843ff7d9845393d651a26bfd584bcc14ab7ad897f6045L105-R146)
* Refactored the `emitMetadata` function to update and emit the accumulated usage, providing real-time usage feedback during streaming.

These changes collectively ensure that token usage is tracked comprehensively and reported accurately throughout the agent's lifecycle, improving transparency, billing accuracy, and developer experience.