### PR TITLE
Remove println and debug output statements from codebase

### DIFF
--- a/agents/src/commonTest/kotlin/AgentMetadataAccumulationTest.kt
+++ b/agents/src/commonTest/kotlin/AgentMetadataAccumulationTest.kt
@@ -88,12 +88,7 @@ class AgentMetadataAccumulationTest {
                 "Total tokens should be at least the sum of prompt and completion tokens"
             )
         }
-        
-        // Log the metadata for debugging
-        println("Non-streaming metadata: prompt=${response.metadata.promptTokens}, " +
-                "completion=${response.metadata.completionTokens}, " +
-                "total=${response.metadata.totalTokens}")
-        
+
         // Verify we got messages including tool interactions
         assertNotNull(response.messages)
         assertTrue(response.messages.isNotEmpty())
@@ -132,13 +127,9 @@ class AgentMetadataAccumulationTest {
         assertNotNull(finalMetadata.value.promptTokens)
         assertNotNull(finalMetadata.value.completionTokens)
         assertNotNull(finalMetadata.value.totalTokens)
-        
+
         // If OpenAI provided usage data, these should be non-zero
         // But some models might not provide usage data, so we just verify the structure
-        println("Got ${metadataResponses.size} metadata emission(s) with final totals: " +
-                "prompt=${finalMetadata.value.promptTokens}, " +
-                "completion=${finalMetadata.value.completionTokens}, " +
-                "total=${finalMetadata.value.totalTokens}")
 
         // Verify we got tool calls
         val toolCalls = responses.filterIsInstance<StreamResponse.ToolCall>()
@@ -173,12 +164,7 @@ class AgentMetadataAccumulationTest {
         val metadataResponses = responses.filterIsInstance<StreamResponse.Metadata>()
         val toolCallResponses = responses.filterIsInstance<StreamResponse.ToolCall>()
         val toolResultResponses = responses.filterIsInstance<StreamResponse.ToolResult>()
-        
-        // Log for debugging
-        println("Total metadata emissions: ${metadataResponses.size}")
-        println("Tool calls: ${toolCallResponses.size}")
-        println("Tool results: ${toolResultResponses.size}")
-        
+
         // We should have at least:
         // - Tool calls for calculator and weather
         assertTrue(toolCallResponses.size >= 1, "Should have at least one tool call")
@@ -188,9 +174,7 @@ class AgentMetadataAccumulationTest {
         // - One at the end (final)
         // With 2 tool calls, we expect at least 2 metadata emissions
         assertTrue(metadataResponses.size >= 2, "Should have at least 2 metadata emissions (intermediate + final)")
-        
-        println("Got ${metadataResponses.size} metadata emissions - intermediate emission is working!")
-        
+
         // Verify that metadata values are accumulating (if non-zero)
         val firstMetadata = metadataResponses.first()
         val lastMetadata = metadataResponses.last()
@@ -245,13 +229,10 @@ class AgentMetadataAccumulationTest {
         assertNotNull(response.metadata.promptTokens)
         assertNotNull(response.metadata.completionTokens)
         assertNotNull(response.metadata.totalTokens)
-        
+
         // When max steps is reached, we should have accumulated metadata from multiple rounds
         // Even if all values are 0 (due to model limitations), the structure should be present
-        println("Max steps metadata: prompt=${response.metadata.promptTokens}, " +
-                "completion=${response.metadata.completionTokens}, " +
-                "total=${response.metadata.totalTokens}")
-        
+
         // Verify consistency if we have actual usage data
         if (response.metadata.totalTokens > 0) {
             assertTrue(

--- a/agents/src/commonTest/kotlin/AgentStructuredOutputTest.kt
+++ b/agents/src/commonTest/kotlin/AgentStructuredOutputTest.kt
@@ -55,8 +55,6 @@ class AgentStructuredOutputTest {
         assertNotNull(response)
         assertEquals("London", response.location)
         assertTrue(response.conditions.isNotEmpty())
-
-        println("Weather Response: $response")
     }
 
     @Test
@@ -71,8 +69,6 @@ class AgentStructuredOutputTest {
         assertTrue(response.name.isNotEmpty())
         assertTrue(response.age > 0)
         assertTrue(response.occupation.isNotEmpty())
-
-        println("Person Info Response: $response")
     }
 
     @Test
@@ -86,12 +82,6 @@ class AgentStructuredOutputTest {
 
         // Verify that we got some responses
         assertTrue(streamResponses.isNotEmpty(), "Stream responses should not be empty")
-
-        // Print all responses for debugging
-        println("All responses:")
-        streamResponses.forEach { response ->
-            println("Response: $response")
-        }
 
         // Verify that we got an end marker
         val endMarkers = streamResponses.filterIsInstance<StreamResponse.End>()
@@ -109,12 +99,6 @@ class AgentStructuredOutputTest {
 
         // Verify that we got some responses
         assertTrue(streamResponses.isNotEmpty(), "Stream responses should not be empty")
-
-        // Print all responses for debugging
-        println("All responses:")
-        streamResponses.forEach { response ->
-            println("Response: $response")
-        }
 
         // Verify that we got an end marker
         val endMarkers = streamResponses.filterIsInstance<StreamResponse.End>()

--- a/agents/src/commonTest/kotlin/AgentStructuredOutputWithToolsTest.kt
+++ b/agents/src/commonTest/kotlin/AgentStructuredOutputWithToolsTest.kt
@@ -136,8 +136,6 @@ class AgentStructuredOutputWithToolsTest {
         assertEquals(Operation.MULTIPLY, lastCalculatorInputInCombinedTest?.operation, "Operation should be 'multiply'")
         assertEquals(7, lastCalculatorInputInCombinedTest?.a, "First number should be 7")
         assertEquals(8, lastCalculatorInputInCombinedTest?.b, "Second number should be 8")
-
-        println("Calculation Response: $response")
     }
 
     @Test
@@ -163,8 +161,6 @@ class AgentStructuredOutputWithToolsTest {
         assertTrue(weatherToolInvokedInCombinedTest, "Weather tool should have been invoked")
         assertNotNull(lastWeatherInputInCombinedTest, "Weather input should not be null")
         assertEquals("San Francisco", lastWeatherInputInCombinedTest?.query, "Query should be 'San Francisco'")
-
-        println("Weather Forecast Response: $response")
     }
 
     @Test
@@ -182,12 +178,6 @@ class AgentStructuredOutputWithToolsTest {
 
         // Verify that we got some responses
         assertTrue(streamResponses.isNotEmpty(), "Stream responses should not be empty")
-
-        // Print all responses for debugging
-        println("All responses:")
-        streamResponses.forEach { response ->
-            println("Response: $response")
-        }
 
         // Verify that we got an end marker
         val endMarkers = streamResponses.filterIsInstance<StreamResponse.End>()
@@ -216,12 +206,6 @@ class AgentStructuredOutputWithToolsTest {
 
         // Verify that we got some responses
         assertTrue(streamResponses.isNotEmpty(), "Stream responses should not be empty")
-
-        // Print all responses for debugging
-        println("All responses:")
-        streamResponses.forEach { response ->
-            println("Response: $response")
-        }
 
         // Verify that we got an end marker
         val endMarkers = streamResponses.filterIsInstance<StreamResponse.End>()

--- a/agents/src/commonTest/kotlin/AgentTest.kt
+++ b/agents/src/commonTest/kotlin/AgentTest.kt
@@ -27,7 +27,6 @@ class AgentTest {
     // Verify the response
     assertNotNull(response)
     assertTrue(response.isNotEmpty())
-    println("Response: $response")
   }
 
   @Test
@@ -82,17 +81,6 @@ class AgentTest {
 
     // Verify that we received chunks
     assertTrue(chunks.isNotEmpty())
-
-    // Print all chunks for debugging
-    chunks.forEach { chunk ->
-      when (chunk) {
-        is StreamResponse.Chunk<*> -> println("Chunk: ${chunk.value}")
-        is StreamResponse.Metadata -> println("Metadata: ${chunk.value}")
-        StreamResponse.End -> println("End of stream")
-        is StreamResponse.ToolCall -> println("ToolCall: ${chunk.value}")
-        is StreamResponse.ToolResult -> println("ToolResult: ${chunk.value}")
-      }
-    }
   }
 
 }

--- a/agents/src/commonTest/kotlin/AgentToolCrashTest.kt
+++ b/agents/src/commonTest/kotlin/AgentToolCrashTest.kt
@@ -37,7 +37,6 @@ class AgentToolCrashTest {
     // Verify the response
     assertNotNull(response)
     assertTrue(response.isNotEmpty())
-    println("Response: $response")
   }
 
 }

--- a/agents/src/commonTest/kotlin/AgentToolRoundsTest.kt
+++ b/agents/src/commonTest/kotlin/AgentToolRoundsTest.kt
@@ -98,7 +98,6 @@ class AgentToolRoundsTest {
         // Verify the response
         assertNotNull(response)
         assertTrue(response.isNotEmpty())
-        println("Response: $response")
 
         // Verify that both tools were invoked and the calculator was used twice
         assertTrue(calculatorInvocationCount > 0, "Calculator tool should have been invoked")
@@ -107,10 +106,6 @@ class AgentToolRoundsTest {
         // We expect at least 3 rounds: calculator, weather, calculator again
         val totalInvocations = calculatorInvocationCount + weatherInvocationCount
         assertTrue(totalInvocations >= 3, "Expected at least 3 tool invocations, but got $totalInvocations")
-
-        println("Calculator invocations: $calculatorInvocationCount")
-        println("Weather invocations: $weatherInvocationCount")
-        println("Total invocations: $totalInvocations")
     }
 
     @Test
@@ -129,20 +124,7 @@ class AgentToolRoundsTest {
 
         val result: Flow<StreamResponse<String>> = agentWithLimitedSteps.stream("call the random generator tool until you get the number `1000` back")
 
-        result.collect {
-            when (it) {
-              is StreamResponse.Chunk<*> ->
-                  print(it.value)
-              StreamResponse.End ->
-                  println("End of stream")
-              is StreamResponse.Metadata ->
-                  println("Metadata: ${it.value}")
-              is StreamResponse.ToolCall ->
-                  println("Tool call: ${it.value}")
-              is StreamResponse.ToolResult ->
-                  println("Tool result: ${it.value}")
-            }
-        }
+        result.collect { }
 
         assertTrue(randomGeneratorToolCount <= 20,
             "Expected at most 20 tool invocations with maxSteps=10 (considering batch processing), but got $randomGeneratorToolCount")

--- a/agents/src/commonTest/kotlin/AgentToolsTest.kt
+++ b/agents/src/commonTest/kotlin/AgentToolsTest.kt
@@ -79,7 +79,6 @@ class AgentToolsTest {
         // Verify the response
         assertNotNull(response)
         assertTrue(response.isNotEmpty())
-        println("Response: $response")
 
         // Verify that the calculator tool was invoked
         assertTrue(calculatorToolInvoked, "Calculator tool should have been invoked")
@@ -119,9 +118,6 @@ class AgentToolsTest {
         // Verify that we got an end marker
         val endMarkers = streamResponses.filterIsInstance<StreamResponse.End>()
         assertTrue(endMarkers.isNotEmpty(), "Should have received an end marker")
-
-        // Print the content chunks for debugging
-        println("Content chunks: ${contentChunks.joinToString { it.value }}")
     }
 
 }

--- a/agents/src/jvmTest/kotlin/ClassSchemaTest.kt
+++ b/agents/src/jvmTest/kotlin/ClassSchemaTest.kt
@@ -30,8 +30,6 @@ class ClassSchemaTest {
             jsonSchema.contains("\"type\"") || jsonSchema.contains("\"properties\""),
             "Schema should contain type or properties: $jsonSchema"
         )
-        
-        println("Input JSON Schema: $jsonSchema")
     }
 
     @Test
@@ -47,8 +45,6 @@ class ClassSchemaTest {
             jsonSchema.contains("\"type\"") || jsonSchema.contains("\"properties\""),
             "Schema should contain type or properties: $jsonSchema"
         )
-        
-        println("Output JSON Schema: $jsonSchema")
     }
 
     @Test
@@ -64,9 +60,6 @@ class ClassSchemaTest {
         val outputSchema = schema.outputJsonSchema()
         assertNotNull(outputSchema)
         assertEquals("TestOutput", schema.outputSerialName())
-        
-        println("Combined Schema - Input: $inputSchema")
-        println("Combined Schema - Output: $outputSchema")
     }
 
     @Test

--- a/mcp/src/jvmMain/kotlin/predictable/mcp/client/MCPClient.kt
+++ b/mcp/src/jvmMain/kotlin/predictable/mcp/client/MCPClient.kt
@@ -124,7 +124,6 @@ class MCPClient private constructor(
     serverConfig: ServerConfig.SSE
   ) : () -> Unit {
     val httpClient = defaultHttpClient()
-    println("Connecting to ${serverConfig.url}")
     client.connect(
       SseClientTransport(
         client = httpClient,
@@ -266,7 +265,6 @@ class MCPClient private constructor(
       block: suspend (MCPClient) -> A
     ): A {
       val mcpClient = MCPClient(config)
-      println("Connecting to MCP servers: ${mcpClient.clients.keys.joinToString { it.toString() }}")
       val closeables = mcpClient.connect()
       var result: A? = null
       try {

--- a/mcp/src/jvmMain/kotlin/predictable/mcp/server/MCPServer.kt
+++ b/mcp/src/jvmMain/kotlin/predictable/mcp/server/MCPServer.kt
@@ -112,9 +112,7 @@ object MCPServer {
     return Tool.Input(
       properties = schema["properties"]?.jsonObject ?: error("Invalid schema: $schema"),
       required = schema["required"]?.jsonArray?.map { it.toString() }
-    ).also {
-      println("Tool Input: $it")
-    }
+    )
   }
 
   /**

--- a/mcp/src/jvmTest/java/predictable/mcp/MCPAgentIntegrationTest.java
+++ b/mcp/src/jvmTest/java/predictable/mcp/MCPAgentIntegrationTest.java
@@ -389,8 +389,6 @@ public class MCPAgentIntegrationTest {
             env
         );
         assertEquals(env, stdioWithEnv.getEnv());
-        
-        System.out.println("ServerConfig @JvmOverloads test passed");
     }
     
     @Test


### PR DESCRIPTION
- Remove println statements from production code (MCPClient, MCPServer)
- Remove System.out.println from Java integration test
- Remove all println statements from test files while preserving test assertions:
  - AgentStructuredOutputTest.kt (4 instances)
  - AgentToolCrashTest.kt (1 instance)
  - AgentToolsTest.kt (2 instances)
  - AgentStructuredOutputWithToolsTest.kt (4 instances)
  - AgentToolRoundsTest.kt (4 instances)
  - AgentTest.kt (6 instances)
  - ClassSchemaTest.kt (3 instances)
  - AgentMetadataAccumulationTest.kt (5 instances)
